### PR TITLE
Allow to create states with "write": false, to make value.gps.* compatible with ioBroker.type-detector.

### DIFF
--- a/lib/life360DbConnector.js
+++ b/lib/life360DbConnector.js
@@ -231,7 +231,8 @@ async function setStateValue(dpId, dpName, dpRead, dpWrite, dpType, dpRole, val,
 
     try {
         //  Create ioBroker state object
-        const obj = createStateDP(dpId, dpName, dpRead || true, dpWrite || true, dpType, dpRole);
+        // fix to make possible create ReadOnly states
+        const obj = createStateDP(dpId, dpName, dpRead || true, dpWrite , dpType, dpRole);
 
         //  Update state
         if (obj) {


### PR DESCRIPTION
Can I propose to to create states with "write": false, to make value.gps.*, to make it compatible with ioBroker.type-detector.
It give possibility to use this attributes in clouds or in other adaptors, which uses type-detector

Changes to be committed:
	modified:   lib/life360DbConnector.js