### PR TITLE
Fix for error in publishCirclePlaces "Cannot read property 'val' of null

### DIFF
--- a/lib/life360DbConnector.js
+++ b/lib/life360DbConnector.js
@@ -830,9 +830,12 @@ async function publishCirclePlaces(idDP, circle) {
             if (!(places.some(myPlace => currentPlaces[i]._id.endsWith(myPlace.id)))) {
                 //  Place does not exists anymore.
                 //  Fix for issue #27: Adapter looses places (connection)
-                let lastSeen = (await adapter.getStateAsync(`${currentPlaces[i]._id}.timestamp`)).val;
+                let lastSeen = (await adapter.getStateAsync(`${currentPlaces[i]._id}.timestamp`));
                 if (!lastSeen) {
                     lastSeen = myTimestamp;
+                }
+                else {
+                    lastSeen = lastSeen.val;
                 }
                 const diffDay = (myTimestamp - lastSeen) / (1000 * 3600 * 24);
                 adapter.log.silly(`Life360 place ${currentPlaces[i].common.name}: ${diffDay} days old, last seen: ${lastSeen}`);


### PR DESCRIPTION
The error full log:
life360.0 (27014) Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch().
life360.0 (27014) unhandled promise rejection: Cannot read property 'val' of null
life360.0 (27014) TypeError: Cannot read property 'val' of null at publishCirclePlaces (/opt/iobroker/node_modules/iobroker.life360/lib/life360DbConnector.js:833:99)
life360.0 (27014) Cannot read property 'val' of null

The same erron in master and develop.

On branch fix_publishCirclePlaces
Changes to be committed:
	modified:   life360DbConnector.js